### PR TITLE
replace inplace operation in wav2vec2 module

### DIFF
--- a/fairseq/models/wav2vec/wav2vec2.py
+++ b/fairseq/models/wav2vec/wav2vec2.py
@@ -741,7 +741,7 @@ class TransformerEncoder(nn.Module):
 
         x_conv = self.pos_conv(x.transpose(1, 2))
         x_conv = x_conv.transpose(1, 2)
-        x += x_conv
+        x = x + x_conv
 
         if not self.layer_norm_first:
             x = self.layer_norm(x)


### PR DESCRIPTION
This PR fixes:

- RuntimeError in new versions of PyTorch (happened with 1.11).
- Potentially wrongly calculated gradients in older versions without a single warning.

With pytorch 1.11 the inplace operation in the `extract_features` function of  `fairseq/models/wav2vec/wav2vec2.py` caused this error (full trace at the end of the message):
```RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: 
[torch.cuda.FloatTensor [128, 768, 49]], which is output 0 of AsStridedBackward0, is at version 2; expected version 1 instead. Hint: the backtrace further above shows the operation that failed to compute its gradient. The variable in question was changed in there or anywhere later. Good luck!
```

Explanation from a pytorch dev: https://discuss.pytorch.org/t/encounter-the-runtimeerror-one-of-the-variables-needed-for-gradient-computation-has-been-modified-by-an-inplace-operation/836/5

According to this other message, this operation may have caused incorrect gradients in older versions of pytorch without a single warning: https://discuss.pytorch.org/t/solved-pytorch1-5-runtimeerror-one-of-the-variables-needed-for-gradient-computation-has-been-modified-by-an-inplace-operation/90256/5


Full trace:
```/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/autograd/__init__.py:173: UserWarning: Error detected in ConvolutionBackward0. Traceback of forward call that caused the error:
  File "downstream_kws.py", line 346, in <module>
    logits = model(x)
  File "/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "downstream_kws.py", line 64, in forward
    output = self.w2v_encoder(**x, features_only=True)
  File "/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/oscar/modelos/wav2kws/fairseq/models/wav2vec/wav2vec2.py", line 502, in forward
    x = self.encoder(x, padding_mask=padding_mask)
  File "/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/oscar/modelos/wav2kws/fairseq/models/wav2vec/wav2vec2.py", line 730, in forward
    x = self.extract_features(x, padding_mask)
  File "/home/oscar/modelos/wav2kws/fairseq/models/wav2vec/wav2vec2.py", line 742, in extract_features
    x_conv = self.pos_conv(x.transpose(1, 2))
  File "/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/nn/modules/container.py", line 141, in forward
    input = module(input)
  File "/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1128, in _call_impl
    result = forward_call(*input, **kwargs)
  File "/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/nn/modules/conv.py", line 302, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/nn/modules/conv.py", line 298, in _conv_forward
    return F.conv1d(input, weight, bias, self.stride,
 (Triggered internally at  ../torch/csrc/autograd/python_anomaly_mode.cpp:104.)
  Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  0%|                                                                                                                                                                                         | 0/241 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "downstream_kws.py", line 356, in <module>
    loss.backward()
  File "/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/_tensor.py", line 363, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph, inputs=inputs)
  File "/home/oscar/modelos/wav2kws/venv3/lib/python3.8/site-packages/torch/autograd/__init__.py", line 173, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [128, 768, 49]], which is output 0 of AsStridedBackward0, is at version 2; expected version 1 instead. Hint: the backtrace further above shows the operation that failed to compute its gradient. The variable in question was changed in there or anywhere later. Good luck!
```